### PR TITLE
Use getPvPEventName instead of getEventName in StrikePracticeQuests

### DIFF
--- a/src/main/java/io/github/battlepass/quests/quests/external/StrikePracticeQuests.java
+++ b/src/main/java/io/github/battlepass/quests/quests/external/StrikePracticeQuests.java
@@ -19,7 +19,7 @@ public class StrikePracticeQuests extends ExternalQuestExecutor {
             return;
         }
         Player player = (Player) event.getHost();
-        String eventName = event.getEventName();
+        String eventName = event.getPvPEventName().toLowerCase();
 
         this.execute("host_events", player, result -> result.root(eventName));
     }


### PR DESCRIPTION
getPvPEventName returns the name of the hosted event (e.g "brackets", "sumo") while getEventName is bukkit's method and returns "PlayerHostEvent".
Also, I added toLowerCase because some versions of StrikePractice may return it in different letter case